### PR TITLE
Add support for timed deploys using ENV vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ deployments:
 gcloud app deploy --project=APPID --promote app.yaml
 ```
 
+Optional: if you plan to use the timed deployments feature, you'll also need to
+deploy a cron.yaml and index.yaml. A sample config files can be found in
+`extensions/fileset/cron.yaml` and `extensions/fileset/index.yaml`
+
+```
+gcloud app deploy --project=APPID cron.yaml index.yaml
+```
+
 7) Generate an auth token
 
 Future:

--- a/fileset/cron.yaml
+++ b/fileset/cron.yaml
@@ -1,0 +1,7 @@
+cron:
+- description: "fileset timed deploys"
+  url: /_fs/api/cron.timed_deploy
+  schedule: every 1 mins
+  retry_parameters:
+    min_backoff_seconds: 5
+    max_doublings: 2

--- a/fileset/index.yaml
+++ b/fileset/index.yaml
@@ -1,0 +1,5 @@
+indexes:
+- kind: FilesetTimedDeploy
+  properties:
+  - name: deployed
+  - name: deploy_timestamp

--- a/fileset/server/main.py
+++ b/fileset/server/main.py
@@ -30,7 +30,11 @@ class MainHandler(blobstore_handlers.BlobstoreDownloadHandler):
         # Determine the branch to use from the URL, and then fetch the branch's
         # fileset manifest.
         branch = utils.get_branch(self.request)
-        manifest = manifests.get_branch_manifest(branch)
+        if branch.startswith('manifest-') and branch[9:].isdigit():
+            manifest_id = int(branch[9:])
+            manifest = manifests.get(manifest_id)
+        else:
+            manifest = manifests.get_branch_manifest(branch)
         if not manifest:
             manifest = manifests.get_branch_manifest(utils.DEFAULT_BRANCH)
             return self.serve_404(manifest, path)

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,8 @@ setuptools.setup(
         'fileset': ['include.yaml'],
     },
     packages=setuptools.find_packages(),
-    install_requires=['GoogleAppEngineCloudStorageClient'],
+    install_requires=[
+        'GoogleAppEngineCloudStorageClient',
+        'pytz',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,11 @@ setuptools.setup(
     author='Grow SDK Authors',
     author_email='hello@grow.io',
     package_data={
-        'fileset': ['include.yaml'],
+        'fileset': [
+            'cron.yaml',
+            'include.yaml',
+            'index.yaml',
+        ],
     },
     packages=setuptools.find_packages(),
     install_requires=[


### PR DESCRIPTION
For projects that build/deploy using a continuous integration service, you can now set a custom ENV var to schedule deployments in the future.

Some notes:

* Subsequent timed deploys to the same branch will be overwritten by the latest deploy. So if person A schedules a timed deploy to branch `master`, and then B schedules one afterwards for the same branch, only B's scheduled deploy will go through.
* Manifests can now be previewed directly using `https://manifest-<manifest id>-dot-<app id>.appspot.com`