### PR TITLE
Add `serve_path()` method to MainHandler

### DIFF
--- a/fileset/server/main.py
+++ b/fileset/server/main.py
@@ -25,7 +25,9 @@ class MainHandler(blobstore_handlers.BlobstoreDownloadHandler):
         _, ext = os.path.splitext(path)
         if not ext:
             path = utils.safe_join(path, 'index.html')
+        self.serve_path(path)
 
+    def serve_path(self, path):
         if path.endswith('.html'):
             # Use case-insensitive paths.
             path = path.lower()


### PR DESCRIPTION
This change makes it easier for subclasses to use fileset's serving logic without having to replicate it.