### PR TITLE
Optimizations for large site uploads

### DIFF
--- a/fileset/grow/ext.py
+++ b/fileset/grow/ext.py
@@ -223,6 +223,7 @@ class FilesetDestination(destinations.BaseDestination):
                     raise
                 manifest['files'].append(data)
 
+        self.pod.podcache.write()
         response = fs.upload_manifest(manifest)
         manifest_id = response.json()['manifest_id']
 

--- a/fileset/grow/ext.py
+++ b/fileset/grow/ext.py
@@ -198,7 +198,10 @@ class FilesetDestination(destinations.BaseDestination):
             logging.error('"token" is required in {}'.format(CONFIG_PATH))
             return
 
-        fs = fileset.FilesetClient(server, token)
+        api_host = server
+        if branch != 'master':
+            api_host = '{}-dot-{}'.format(branch, server)
+        fs = fileset.FilesetClient(api_host, token)
         manifest = {
             'commit': self.get_commit(),
             'files': [],
@@ -262,7 +265,8 @@ class FilesetDestination(destinations.BaseDestination):
     def _upload_blob(self, fs, rendered_doc):
         sha = rendered_doc.hash
         path = rendered_doc.path
-        blobkey = '{host}::blob::{sha}'.format(host=fs.host, sha=sha)
+        blobkey = '{server}::blob::{sha}'.format(
+            server=self.config.server, sha=sha)
         if not self.objectcache.get(blobkey) and not fs.blob_exists(sha):
             logging.info('uploading blob {} {}'.format(sha, path))
             fs.upload_blob(sha, path, rendered_doc.read())

--- a/fileset/grow/ext.py
+++ b/fileset/grow/ext.py
@@ -204,7 +204,7 @@ class FilesetDestination(destinations.BaseDestination):
             'files': [],
         }
 
-        with futures.ThreadPoolExecutor(max_workers=5) as executor:
+        with futures.ThreadPoolExecutor(max_workers=20) as executor:
             # Map of future => doc path.
             results = {}
             for rendered_doc in content_generator:

--- a/fileset/server/api.py
+++ b/fileset/server/api.py
@@ -60,13 +60,10 @@ class ManifestUploadHandler(RpcHandler):
         data = json.loads(content)
 
         paths = {}
-        files_needed = []
         for file_data in data['files']:
             sha = file_data['sha']
             path = file_data['path']
             paths[path] = sha
-            if not blobs.exists(sha):
-                files_needed.append(file_data)
 
         commit = data['commit']
         manifest_id = manifests.save(commit, paths)
@@ -74,7 +71,6 @@ class ManifestUploadHandler(RpcHandler):
         return self.json({
             'success': True,
             'manifest_id': manifest_id,
-            'files_needed': files_needed,
         })
 
 

--- a/fileset/server/auth.py
+++ b/fileset/server/auth.py
@@ -35,7 +35,7 @@ def create_auth_token(description):
 
 def is_token_valid(token):
     memcache_key = 'fs-token-valid:{}'.format(token)
-    if memcache.get(memcache_key) == 'true':
+    if memcache.get(memcache_key) == '1':
         return True
 
     ent = FilesetAuthToken.get_by_id(token)
@@ -49,7 +49,7 @@ def is_token_valid(token):
     #     ent.put_async()
 
     if is_valid:
-        memcache.set(memcache_key, 'true')
+        memcache.set(memcache_key, '1')
     return is_valid
 
 


### PR DESCRIPTION
Changes include:

* Used memcache to speed up DB ops (like auth lookups)
* Temporarily removed `auth_token.last_used` timestamp to prevent datastore write contention
* Remove files_needed check from manifest.upload (it'll be up to the client to ensure all blobs exist before manifests are saved)
* Upload blobs using a thread pool
* Manually save objectcache files for any blob upload errors
* Use `{branch}-dot-{appid}.appspot.com` as API endpoint (will automatically fall back to the default version if the branched URL doesn't exist)